### PR TITLE
Updated quantity and added currency

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -289,7 +289,7 @@ components:
                 unitInfo:
                   unitPrice: 400
                   quantity: '2.5'
-                  quantityUnit: kg
+                  quantityUnit: KG
                 discount: 0
                 productUrl: www.vipps.no/store/banana
               - name: Soap 3for2
@@ -302,13 +302,24 @@ components:
                 unitInfo:
                   unitPrice: 2500
                   quantity: '3'
-                  quantityUnit: pcs
+                  quantityUnit: PCS
                 discount: 2500
                 productUrl: www.vipps.no/store/soap
     BottomLine:
       title: BottomLine
       type: object
       description: 'Summary of the order. Total amount and total '
+      x-examples:
+        BottomLineExample:
+          value:
+            totalAmount: 6000
+            totalTax: 1200
+            totalDiscount: 2500
+            currency: NOK
+            shippingAmount: 0
+            tipAmount: 0
+            giftCardAmount: 0
+            terminalId: vipps_pos_122
       properties:
         totalAmount:
           type: integer
@@ -342,17 +353,6 @@ components:
         - totalAmount
         - totalTax
         - currency
-      x-examples:
-        BottomLineExample:
-          value:
-            totalAmount: 6000
-            totalTax: 1200
-            totalDiscount: 2500
-            currency: NOK
-            shippingAmount: 0
-            tipAmount: 0
-            giftCardAmount: 0
-            terminalId: vipps_pos_122
     UnitInfo:
       title: UnitInfo
       type: object
@@ -362,12 +362,12 @@ components:
           value:
             quantity: '0.822'
             unitPrice: 15000
-            quantityUnit: kg
+            quantityUnit: KG
         example-2:
           value:
             quantity: '2'
             unitPrice: 20000
-            quantityUnit: pcs
+            quantityUnit: PCS
       properties:
         unitPrice:
           type: integer
@@ -404,14 +404,13 @@ components:
       type: string
       title: QuantityUnitEnum
       enum:
-        - Minute
-        - kg
-        - cm
-        - pcs
-        - Litre
-        - Metre
-        - Gram
+        - PCS
+        - KG
+        - KM
+        - MINUTE
+        - LITRE
       description: Available units for quantity. Will default to pcs if not set
+      default: PCS
   securitySchemes:
     BearerToken:
       type: http

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -204,64 +204,6 @@ components:
       x-examples:
         example-1:
           imageId: laptop_image4433
-    OrderLine:
-      title: OrderLine
-      type: object
-      description: 'All numbers are interpreted as integers with two trailing zeros. ex: 10.00 = 1000'
-      properties:
-        amountExcludingTax:
-          type: integer
-          nullable: true
-        amountIncludingTax:
-          type: integer
-          nullable: true
-        description:
-          type: string
-        id:
-          type: string
-          description: The product ID
-        productUrl:
-          type: string
-          nullable: true
-        quantity:
-          type: integer
-          nullable: true
-        taxAmount:
-          type: integer
-          nullable: true
-        taxPercentage:
-          type: integer
-          nullable: true
-        discount:
-          type: integer
-          nullable: true
-        quantityUnit:
-          $ref: '#/components/schemas/QuantityUnitEnum'
-      required:
-        - amountExcludingTax
-        - amountIncludingTax
-        - description
-        - id
-        - quantity
-        - taxAmount
-        - taxPercentage
-        - discount
-        - quantityUnit
-    Receipt:
-      title: Receipt
-      type: object
-      properties:
-        orderLines:
-          type: array
-          minItems: 1
-          items:
-            $ref: '#/components/schemas/OrderLine'
-        shippingAmount:
-          type: integer
-          nullable: true
-      required:
-        - orderLines
-        - shippingAmount
     ImageId:
       title: ImageId
       type: object
@@ -282,18 +224,163 @@ components:
         - delivery
         - ticket
         - booking
+    Receipt:
+      title: Receipt
+      type: object
+      properties:
+        orderLines:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/OrderLine'
+        bottomLine:
+          $ref: '#/components/schemas/BottomLine'
+      required:
+        - orderLines
+        - bottomLine
+    OrderLine:
+      title: OrderLine
+      type: object
+      description: 'All numbers are interpreted as integers with two trailing zeros. ex: 10.00 = 1000'
+      properties:
+        totalAmount:
+          type: integer
+          description: Total amount of the order line
+          nullable: true
+        totalAmountExcludingTax:
+          type: integer
+          description: Total amount of order line excluding tax
+          nullable: true
+        totalTaxAmount:
+          type: integer
+          description: Total tax amount for the order line
+          nullable: true
+        taxPercentage:
+          type: integer
+          description: Tax percantage for the order line
+          nullable: true
+        currency:
+          $ref: '#/components/schemas/CurrencyEnum'
+        name:
+          type: string
+          description: Name of the product in the order line
+        id:
+          type: string
+          description: The product ID
+        unitInfo:
+          $ref: '#/components/schemas/UnitInfo'
+        discount:
+          type: integer
+          description: Total discount for the order line
+          nullable: true
+        quantityUnit:
+          $ref: '#/components/schemas/QuantityUnitEnum'
+        productUrl:
+          type: string
+          description: ''
+          nullable: true
+        unitPrice:
+          type: string
+      required:
+        - totalAmount
+        - totalAmountExcludingTax
+        - totalTaxAmount
+        - taxPercentage
+        - currency
+        - name
+        - id
+        - unitInfo
+        - discount
+        - quantityUnit
+    BottomLine:
+      title: BottomLine
+      type: object
+      description: Summary of the order
+      properties:
+        totalAmount:
+          type: string
+        totalTax:
+          type: string
+        totalDiscount:
+          type: string
+        currency:
+          $ref: '#/components/schemas/CurrencyEnum'
+        shippingAmount:
+          type: integer
+          description: Shipping amount for the order
+          nullable: true
+        tipAmount:
+          type: integer
+          description: Tip amount for the order
+          nullable: true
+        terminalId:
+          type: string
+        recycleDiscount:
+          type: string
+          description: 'Discount due to recycling '
+        coupon:
+          type: string
+          description: Amount paid by gift card or coupon
+      required:
+        - totalAmount
+        - totalTax
+        - totalDiscount
+        - currency
+    UnitInfo:
+      title: UnitInfo
+      type: object
+      description: Optional. If no quantity info is provided the order line will default to 1 pcs
+      x-examples:
+        example-1:
+          value:
+            quantity: '0.822'
+            unitPrice: 15000
+            quantityUnit: kg
+        example-2:
+          value:
+            quantity: '2'
+            unitPrice: 20000
+            quantityUnit: pcs
+      properties:
+        unitPrice:
+          type: integer
+          description: Price per unit
+          nullable: true
+        quantity:
+          type: string
+          maxLength: 10
+          pattern: '^\d+([\.]\d{1,8})?$'
+          example: '0.822'
+          description: 'Quantity given as a integer or fraction '
+        quantityUnit:
+          $ref: '#/components/schemas/QuantityUnitEnum'
+        '':
+          type: string
+      required:
+        - unitPrice
+        - quantity
+        - quantityUnit
+    CurrencyEnum:
+      type: string
+      title: CurrencyEnum
+      enum:
+        - EUR
+        - NOK
+        - SEK
+        - DKK
+        - GBP
     QuantityUnitEnum:
       type: string
       title: QuantityUnitEnum
       enum:
-        - Unknown
-        - Meter
-        - Liter
         - Minute
         - kg
-        - Gram
         - cm
-      description: Quantity must be given as non-decimal numbers
+        - pcs
+        - Litre
+        - Metre
+        - Gram
+      description: Available units for quantity. Will default to pcs if not set
   securitySchemes:
     BearerToken:
       type: http

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -95,7 +95,7 @@ paths:
             schema:
               $ref: '#/components/schemas/Image'
             examples:
-              example-1:
+              ImageUploadExample:
                 value:
                   imageId: laptop_image4433
                   src: iVBORw0KGgoAAAANSUhEUgAAAKsAAADVCAMAAAAfHv
@@ -126,45 +126,12 @@ paths:
             schema:
               $ref: '#/components/schemas/Receipt'
             examples:
-              example-1:
+              ReceiptExample:
                 value:
                   orderLines:
-                    - totalAmount: 1000
-                      totalAmountExcludingTax: 800
-                      totalTaxAmount: 200
-                      taxPercentage: 25
-                      currency: NOK
-                      name: Banana
-                      id: line_item_1
-                      unitInfo:
-                        unitPrice: 400
-                        quantity: '2.5'
-                        quantityUnit: kg
-                      discount: 0
-                      productUrl: www.vipps.no/store/banana
-                    - totalAmount: 2500
-                      totalAmountExcludingTax: 4000
-                      totalTaxAmount: 1000
-                      taxPercentage: 25
-                      currency: NOK
-                      name: Soap
-                      id: line_item_2
-                      unitInfo:
-                        unitPrice: 1000
-                        quantity: '5'
-                        quantityUnit: pcs
-                      discount: 2500
-                      productUrl: www.vipps.no/store/soap
+                    $ref: '#/components/schemas/OrderLine/x-examples/OrderLineExample/value/orderLines'
                   bottomLine:
-                    totalAmount: 3500
-                    totalTax: 1200
-                    totalDiscount: 2500
-                    currency: NOK
-                    shippingAmount: 0
-                    tipAmount: 0
-                    terminalId: cashier_ref_31133
-                    recycleDiscount: 0
-                    coupon: 0
+                    $ref: '#/components/schemas/BottomLine/x-examples/BottomLineExample/value'
       description: Endpoint for uploading receipts to Vipps.
       security:
         - BearerToken: []
@@ -207,8 +174,8 @@ components:
           format: uri
           description: URL linking back to the merchant.
           minLength: 1
-        image:
-          $ref: '#/components/schemas/ImageId'
+        imageId:
+          type: string
       required:
         - category
         - orderDetailsUrl
@@ -237,6 +204,7 @@ components:
             imageId: laptop_image4433
             src: iVBORw0KGgoAAAANSUhEUgAAAKsAAADVCAMAAAAfHv
             type: base64
+      title: ''
     ImageResponse:
       type: object
       properties:
@@ -245,16 +213,6 @@ components:
       x-examples:
         example-1:
           imageId: laptop_image4433
-    ImageId:
-      title: ImageId
-      type: object
-      properties:
-        id:
-          type: string
-          pattern: '^[0-9A-Za-z-_\.]+$'
-          maxLength: 128
-      required:
-        - id
     CategoryEnum:
       type: string
       title: CategoryEnum
@@ -284,17 +242,23 @@ components:
       type: object
       description: 'All numbers are interpreted as integers with two trailing zeros. ex: 10.00 = 1000'
       properties:
+        name:
+          type: string
+          description: Name of the product in the order line
+        id:
+          type: string
+          description: The product ID
         totalAmount:
           type: integer
-          description: Total amount of the order line
+          description: 'Total amount of the order line, including tax and discount'
           nullable: true
         totalAmountExcludingTax:
           type: integer
-          description: Total amount of order line excluding tax
+          description: 'Total amount of order line with discount excluding tax '
           nullable: true
         totalTaxAmount:
           type: integer
-          description: Total tax amount for the order line
+          description: Total tax amount paid for the order line
           nullable: true
         taxPercentage:
           type: integer
@@ -302,12 +266,6 @@ components:
           nullable: true
         currency:
           $ref: '#/components/schemas/CurrencyEnum'
-        name:
-          type: string
-          description: Name of the product in the order line
-        id:
-          type: string
-          description: The product ID
         unitInfo:
           $ref: '#/components/schemas/UnitInfo'
         discount:
@@ -316,25 +274,55 @@ components:
           nullable: true
         productUrl:
           type: string
-          description: ''
+          description: Optional URL linking back to the product at the merchant
           nullable: true
       required:
+        - name
+        - id
         - totalAmount
         - totalAmountExcludingTax
         - totalTaxAmount
         - taxPercentage
         - currency
-        - name
-        - id
         - discount
+      x-examples:
+        OrderLineExample:
+          value:
+            orderLines:
+              - name: Banana
+                id: line_item_1
+                totalAmount: 1000
+                totalAmountExcludingTax: 800
+                totalTaxAmount: 200
+                taxPercentage: 25
+                currency: NOK
+                unitInfo:
+                  unitPrice: 400
+                  quantity: '2.5'
+                  quantityUnit: kg
+                discount: 0
+                productUrl: www.vipps.no/store/banana
+              - name: Soap 3for2
+                id: line_item_2
+                totalAmount: 5000
+                totalAmountExcludingTax: 4000
+                totalTaxAmount: 1000
+                taxPercentage: 25
+                currency: NOK
+                unitInfo:
+                  unitPrice: 2500
+                  quantity: '3'
+                  quantityUnit: pcs
+                discount: 2500
+                productUrl: www.vipps.no/store/soap
     BottomLine:
       title: BottomLine
       type: object
-      description: Summary of the order
+      description: 'Summary of the order. Total amount and total '
       properties:
         totalAmount:
           type: integer
-          description: 'Total amount of the order, including tax and excluding all discount'
+          description: 'The total amount the order, including all taxes and discounts'
           nullable: true
         totalTax:
           type: integer
@@ -354,20 +342,27 @@ components:
           type: integer
           description: Tip amount for the order
           nullable: true
-        terminalId:
-          type: string
-        recycleDiscount:
-          type: integer
-          description: 'Discount due to recycling '
-          nullable: true
-        coupon:
+        giftCardAmount:
           type: integer
           description: Amount paid by gift card or coupon
           nullable: true
+        terminalId:
+          type: string
       required:
         - totalAmount
         - totalTax
         - currency
+      x-examples:
+        BottomLineExample:
+          value:
+            totalAmount: 6000
+            totalTax: 1200
+            totalDiscount: 2500
+            currency: NOK
+            shippingAmount: 0
+            tipAmount: 0
+            giftCardAmount: 0
+            terminalId: vipps_pos_122
     UnitInfo:
       title: UnitInfo
       type: object

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -30,7 +30,7 @@ paths:
               examples:
                 Retrieve order info:
                   value:
-                    category: Ticket
+                    category: TICKET
                     orderDetailsUrl: 'https://www.vipps.no'
                     imageIds:
                       - id: laptop_image4433
@@ -58,7 +58,7 @@ paths:
             examples:
               Adding order metadata with one image:
                 value:
-                  category: General
+                  category: GENERAL
                   orderDetailsUrl: 'https://www.vipps.no'
                   imageIds:
                     - id: laptop_image4433
@@ -160,7 +160,7 @@ components:
       x-examples:
         example-1:
           value:
-            category: general
+            category: GENERAL
             orderDetailsUrl: 'https://www.vipps.no'
             image:
               id: laptop_image4433
@@ -213,16 +213,6 @@ components:
       x-examples:
         example-1:
           imageId: laptop_image4433
-    CategoryEnum:
-      type: string
-      title: CategoryEnum
-      enum:
-        - General
-        - Receipt
-        - OrderConfirmation
-        - Delivery
-        - Ticket
-        - Booking
     Receipt:
       title: Receipt
       type: object
@@ -395,6 +385,16 @@ components:
         - unitPrice
         - quantity
         - quantityUnit
+    CategoryEnum:
+      type: string
+      title: CategoryEnum
+      enum:
+        - GENERAL
+        - RECEIPT
+        - ORDER_CONFIRMATION
+        - DELIVERY
+        - TICKET
+        - BOOKING
     CurrencyEnum:
       type: string
       title: CurrencyEnum

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -30,7 +30,7 @@ paths:
               examples:
                 Retrieve order info:
                   value:
-                    category: ticket
+                    category: Ticket
                     orderDetailsUrl: 'https://www.vipps.no'
                     imageIds:
                       - id: laptop_image4433
@@ -58,7 +58,7 @@ paths:
             examples:
               Adding order metadata with one image:
                 value:
-                  category: general
+                  category: General
                   orderDetailsUrl: 'https://www.vipps.no'
                   imageIds:
                     - id: laptop_image4433
@@ -125,6 +125,46 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Receipt'
+            examples:
+              example-1:
+                value:
+                  orderLines:
+                    - totalAmount: 1000
+                      totalAmountExcludingTax: 800
+                      totalTaxAmount: 200
+                      taxPercentage: 25
+                      currency: NOK
+                      name: Banana
+                      id: line_item_1
+                      unitInfo:
+                        unitPrice: 400
+                        quantity: '2.5'
+                        quantityUnit: kg
+                      discount: 0
+                      productUrl: www.vipps.no/store/banana
+                    - totalAmount: 2500
+                      totalAmountExcludingTax: 4000
+                      totalTaxAmount: 1000
+                      taxPercentage: 25
+                      currency: NOK
+                      name: Soap
+                      id: line_item_2
+                      unitInfo:
+                        unitPrice: 1000
+                        quantity: '5'
+                        quantityUnit: pcs
+                      discount: 2500
+                      productUrl: www.vipps.no/store/soap
+                  bottomLine:
+                    totalAmount: 3500
+                    totalTax: 1200
+                    totalDiscount: 2500
+                    currency: NOK
+                    shippingAmount: 0
+                    tipAmount: 0
+                    terminalId: cashier_ref_31133
+                    recycleDiscount: 0
+                    coupon: 0
       description: Endpoint for uploading receipts to Vipps.
       security:
         - BearerToken: []
@@ -140,6 +180,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Receipt'
+              examples: {}
       description: Endpoint for downloading receipts to Vipps.
       security:
         - BearerToken: []
@@ -218,12 +259,12 @@ components:
       type: string
       title: CategoryEnum
       enum:
-        - general
-        - receipt
-        - orderConfirmation
-        - delivery
-        - ticket
-        - booking
+        - General
+        - Receipt
+        - OrderConfirmation
+        - Delivery
+        - Ticket
+        - Booking
     Receipt:
       title: Receipt
       type: object
@@ -273,14 +314,10 @@ components:
           type: integer
           description: Total discount for the order line
           nullable: true
-        quantityUnit:
-          $ref: '#/components/schemas/QuantityUnitEnum'
         productUrl:
           type: string
           description: ''
           nullable: true
-        unitPrice:
-          type: string
       required:
         - totalAmount
         - totalAmountExcludingTax
@@ -289,20 +326,24 @@ components:
         - currency
         - name
         - id
-        - unitInfo
         - discount
-        - quantityUnit
     BottomLine:
       title: BottomLine
       type: object
       description: Summary of the order
       properties:
         totalAmount:
-          type: string
+          type: integer
+          description: 'Total amount of the order, including tax and excluding all discount'
+          nullable: true
         totalTax:
-          type: string
+          type: integer
+          description: Total tax for the order
+          nullable: true
         totalDiscount:
-          type: string
+          type: integer
+          description: Total discount from the orderLines
+          nullable: true
         currency:
           $ref: '#/components/schemas/CurrencyEnum'
         shippingAmount:
@@ -316,15 +357,16 @@ components:
         terminalId:
           type: string
         recycleDiscount:
-          type: string
+          type: integer
           description: 'Discount due to recycling '
+          nullable: true
         coupon:
-          type: string
+          type: integer
           description: Amount paid by gift card or coupon
+          nullable: true
       required:
         - totalAmount
         - totalTax
-        - totalDiscount
         - currency
     UnitInfo:
       title: UnitInfo
@@ -344,7 +386,7 @@ components:
       properties:
         unitPrice:
           type: integer
-          description: Price per unit
+          description: 'Total price per unit, including tax and excluding discount'
           nullable: true
         quantity:
           type: string
@@ -354,8 +396,6 @@ components:
           description: 'Quantity given as a integer or fraction '
         quantityUnit:
           $ref: '#/components/schemas/QuantityUnitEnum'
-        '':
-          type: string
       required:
         - unitPrice
         - quantity
@@ -364,11 +404,7 @@ components:
       type: string
       title: CurrencyEnum
       enum:
-        - EUR
         - NOK
-        - SEK
-        - DKK
-        - GBP
     QuantityUnitEnum:
       type: string
       title: QuantityUnitEnum


### PR DESCRIPTION
- Added currency on all items
- Added bottomline with summary of transaction
- Added coupons and recycle-discount to bottomline summary
- Made quantity into a textfield that supports strings like "0.002" and "125"

The idea behind quantity here is to only provide it when something else than 1pcs is needed. For now, we will only use the total amount per order line when shown in the app, but some time we might want to show more info

I am unsure if we should also ask for tax and taxPercentage per unit as well, because im not sure if we need it


The idea behind bottomline is to skip all internal calculations. I believe its better to let the merchants calculate everything for us to avoid any rounding conflicts. 