### PR TITLE
Add metadata to MD files for vipps-order-management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
+<!-- START_METADATA
+---
+title: Introduction
+sidebar_position: 1
+---
+END_METADATA -->
+
 # Vipps Order Management API v2
+
 This repository contains developer resources for the Vipps Order Management API. The Vipps Order Management API allows merchants to enrich Vipps transactions with a [Receipt](#receipts) and a [Category](#category) that contains an image. This information is shown to the customer in the app in their order history and right after in-store purchases.
 
 The purpose of enriching transactions is to give
@@ -6,6 +14,7 @@ your customers more convenience, better overview and a more compelling shopping
 experience when they use Vipps to pay for your products and services.
 Vipps Order management also enables you to draw customers back to your website
 or app from links on the Vipps receipt view.
+
 This functionality is available for
 [recurring](https://github.com/vippsas/vipps-recurring-api)
 and
@@ -14,20 +23,25 @@ but not for
 [passthrough payments](https://github.com/vippsas/vipps-psp-api).
 
 Detailed documentation on how to use the Order Management Api can be found here:
+
 * [API Guide](vipps-order-management-api.md)
 
 You can peruse the API reference documentation as:
+
 * [Swagger UI](https://vippsas.github.io/vipps-order-management-api/)
 * [ReDoc](https://vippsas.github.io/vipps-order-management-api/redoc.html)
 
-# Receipts
+## Receipts
+
 The `receipt` concept will allow the merchant to add order lines to a Vipps Transaction. This can be used as proof of purchase when returning goods, as an electronic copy for expensing or in scenarios where a paper printer is not available. We also know our customers love this information.
 * [Receipts API Guide](vipps-order-management-api.md#receipts)
 <p align="center">
   <img src="images/order-lines.png" width="150" />
 </p>
 
-# Categories and Images
+
+## Categories and Images
+
 The `category` concept may be added to a Vipps Transaction to give extra information and can be used as a way to draw customers back to the merchants web page. In addition to the category, it is possible to add a image to the Vipps transaction.
 * [Categories API Guide](vipps-order-management-api.md#categories)
 

--- a/vipps-order-management-api.md
+++ b/vipps-order-management-api.md
@@ -1,4 +1,5 @@
-<!-- START_METADATA---
+<!-- START_METADATA
+---
 title: API Guide
 sidebar_position: 12
 ---

--- a/vipps-order-management-api.md
+++ b/vipps-order-management-api.md
@@ -1,3 +1,9 @@
+<!-- START_METADATA---
+title: API Guide
+sidebar_position: 12
+---
+END_METADATA -->
+
 # Vipps Order Management API v2
 
 The Order Management API allows merchants to enrich Vipps Transactions.
@@ -15,7 +21,9 @@ API version: 2.3.0.
 
 Document version: 1.1.2.
 
+<!-- START_TOC -->
 ## Table of contents
+
 - [Vipps Order Management API v2](#vipps-order-management-api-v2)
   - [Table of contents](#table-of-contents)
 - [Before you begin](#before-you-begin)
@@ -35,6 +43,7 @@ Document version: 1.1.2.
     - [Mandatory use case](#mandatory-use-case)
   - [Questions?](#questions)
 
+<!-- END_TOC -->
 
 # Before you begin
 
@@ -81,6 +90,7 @@ everyone sends it too. It can speed up any trouble-shooting quite a bit.
 | `Vipps-System-Plugin-Version` | The version number of the ecommerce plugin   | `1.4.1`             |
 
 ## OrderId and PaymentType
+
 The idea with order management is to add a Receipt or Category to a Vipps transaction made with the Ecom or Recurring API. So, the receipt needs to be connected to a `OrderId`. The `OrderId` is what **you** use when either initiating a Ecom payment or creating a recurring charge.
 
 The Order Management API does **no validation if the order exists**. This means that the order management enrichment may be added before or after the payment is actually created. The preferred way is to add the Order Management Data simultaneously as you initiate the payment. 
@@ -88,6 +98,7 @@ The Order Management API does **no validation if the order exists**. This means 
 As the same OrderId can be used for both a Recurring charge and a Ecom payment, you need to supply which Vipps Product is being used by setting the appropriate `paymentType`
 
 ## Basic flow
+
 1. Initiate a Vipps eCom or recurring payment
     - `POST:/ecomm/v2/payments` 
 2. Save the **orderId** you used when initiating
@@ -101,12 +112,14 @@ As the same OrderId can be used for both a Recurring charge and a Ecom payment, 
 
 
 # Categories
+
 * [API Documentation with examples here](https://vippsas.github.io/vipps-order-management-api/redoc.html#tag/Category)
 
 The following section will explain how to enrich a Vipps transaction with `Categories` and `Images`. `Link` and `Category` are required when using this API,
 whereas `Images` are optional.
 
 ## Category
+
 In order to provide customers with more up-to-date information about their order,
 you can add a `Category`. This creates a link on the Vipps Transaction page of the Vipps app and can take the
 customer to a location on your website. Links are activated when a customer
@@ -122,6 +135,7 @@ The category will determine how the app handles the link, additional information
 You can only use one category. If you send more than one, only the last one will be shown in the app.
 
 We currently support these categories:
+
 | Category                      | Description                                  | Example images      |
 | ----------------------------- | -------------------------------------------- | ------------------- |
 | `Receipt`                     | A link to a location where the customer can access and download a valid proof of purchase and receipt for this particular order.     | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ![show receipt example](images/show-receipt.png) ![show receipt example](images/show-receipt-img.png)|
@@ -153,6 +167,7 @@ transaction containing an Image with the "Shipping information" `Category`.
 </p>
 
 ## Adding an Image
+
 [`POST:/order-management/v1/images`](https://vippsas.github.io/vipps-order-management-api/#/images/postImage)
 
 Endpoint for uploading pictures. Images exist independently of any transaction.
@@ -189,6 +204,7 @@ The response will then look like this:
 }
 ```
 ## Adding and changing Category
+
 [`PUT:/v2/{paymentType}/categories/{orderId}`](https://vippsas.github.io/vipps-order-management-api/redoc.html#operation/putCategoryV2)
 
 This is the endpoint used for adding and updating the Category for a Vipps Transaction. The category is mutable, and a new request will completely overwrite previous requests. Here is an example request:
@@ -210,6 +226,7 @@ By using the [`POST:/receipts`](https://vippsas.github.io/vipps-order-management
 </p>
 
 ## Adding a Receipt
+
 [`POST:/v2/{paymentType}/receipts/{orderId}`](https://vippsas.github.io/vipps-order-management-api/redoc.html#operation/postReceiptV2)
 
 This is the endpoint for sending receipt information. Receipt information is a combination of a list of orderLines, and a bottom line with sum and vat. An OrderLine is a description of each item present in the order. Detailed information about each property is available in the [swagger](https://vippsas.github.io/vipps-order-management-api/redoc.html#operation/postReceiptV2). A receipt is immutable and, once sent, cannot be overwritten.
@@ -289,6 +306,7 @@ Body:
 ```
 
 ## Fetching Category and Receipt
+
 [`GET:/v2/{paymentType}/{orderId}`](https://vippsas.github.io/vipps-order-management-api/redoc.html#operation/getOrderV2)
 
 This endpoint is used for getting both `Category` and `Receipt` for the Vipps Transaction. The response body includes ID references to images previously uploaded, Links, and the OrderLines added.


### PR DESCRIPTION
Added metadata to the top. This is not visible in the Github preview.
I also added empty lines between headings and following lines because this (especially for tables) gets broken in docusaurus.