### PR TITLE
Endpoint corrections + references

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Vipps Order Management API
-  version: '1.0'
+  version: '1.1.0'
   description: >-
     API to add and read additional info for Vipps orders.
     See the [API Guide](https://vippsas.github.io/vipps-developer-docs/docs/APIs/order-management-api) for more information.
@@ -12,7 +12,7 @@ servers:
   - url: 'https://api.vipps.no/order-management'
     description: Vipps Order Management API
 paths:
-  '/v1/orders/{transactionId}':
+  '/order-management/v1/orders/{transactionId}':
     parameters:
       - schema:
           type: string
@@ -73,7 +73,7 @@ paths:
       tags:
         - Order
       deprecated: true
-  /v1/images:
+  /order-management/v1/images:
     parameters: []
     post:
       summary: Add an image
@@ -183,7 +183,7 @@ paths:
                     tipAmount: 0
                     giftCardAmount: 0
                     terminalId: vipps_pos_122
-  '/v1/receipts/{transactionId}':
+  '/order-management/v1/receipts/{transactionId}':
     parameters:
       - schema:
           type: string

--- a/vipps-order-management-api.md
+++ b/vipps-order-management-api.md
@@ -37,7 +37,7 @@ but not for
 
 API version: 2.3.0.
 
-Document version: 1.2.0.
+Document version: 1.2.1.
 
 <!-- START_TOC -->
 ## Table of contents
@@ -93,17 +93,18 @@ As the same OrderId can be used for both a Recurring charge and a Ecom payment, 
 
 ### Basic flow
 
-1. Initiate a Vipps eCom or recurring payment
-    - `POST:/ecomm/v2/payments`
-2. Save the **orderId** you used when initiating
+1. Initiate a Vipps eCom API payment or a Vipps Recurring API charge:
+  [`POST:/ecomm/v2/payments`](https://vippsas.github.io/vipps-developer-docs/api/ecom#tag/Vipps-eCom-API/operation/initiatePaymentV3UsingPOST)
+  or
+  [https://vippsas.github.io/vipps-developer-docs/api/recurring#tag/Charge-v2-endpoints/operation/CreateCharge]
+2. Save the `orderId` you used when initiating.
 3. Add an image (optional)
-    - `POST:/v1/images`
-4. Save the imageId
+  [`POST:/v1/images`](https://vippsas.github.io/vipps-developer-docs/api/order-management#tag/Image/operation/postImage)
+4. Save the `imageId`
 5. Add a category with link and image
-    - `/v2/{paymentType}/categories/{orderId}`
+  [`POST:/order-management/v1/{paymentType}/categories/{orderId}`](https://vippsas.github.io/vipps-developer-docs/api/order-management#tag/Category/operation/putCategoryV2)
 6. Add a receipt
-    - `/v2/{paymentType}/receipts/{orderId}`
-
+  [`POST:/order-management/v1/{paymentType}/receipts/{orderId}`](https://vippsas.github.io/vipps-developer-docs/api/order-management#tag/Receipt/operation/postReceiptV2)
 
 ## Categories
 
@@ -303,7 +304,7 @@ Body:
 
 ### Fetching Category and Receipt
 
-[`GET:/v2/{paymentType}/{orderId}`](https://vippsas.github.io/vipps-developer-docs/api/order-management#operation/getOrderV2)
+[`GET:/order-management/v2/{paymentType}/{orderId}`](https://vippsas.github.io/vipps-developer-docs/api/order-management#tag/Order/operation/getOrderV2)
 
 This endpoint is used for getting both `Category` and `Receipt` for the Vipps Transaction. The response body includes ID references to images previously uploaded, Links, and the OrderLines added.
 

--- a/vipps-order-management-api.md
+++ b/vipps-order-management-api.md
@@ -99,7 +99,7 @@ As the same OrderId can be used for both a Recurring charge and a Ecom payment, 
   [https://vippsas.github.io/vipps-developer-docs/api/recurring#tag/Charge-v2-endpoints/operation/CreateCharge]
 2. Save the `orderId` you used when initiating.
 3. Add an image (optional)
-  [`POST:/v1/images`](https://vippsas.github.io/vipps-developer-docs/api/order-management#tag/Image/operation/postImage)
+  [`POST:/order-management/v1/images`](https://vippsas.github.io/vipps-developer-docs/api/order-management#tag/Image/operation/postImage)
 4. Save the `imageId`
 5. Add a category with link and image
   [`POST:/order-management/v1/{paymentType}/categories/{orderId}`](https://vippsas.github.io/vipps-developer-docs/api/order-management#tag/Category/operation/putCategoryV2)


### PR DESCRIPTION
This needs a proper review:
- Is it `v1` or `v2`?
- Is the Swagger correct?
- All endpoint references in the API guide, etc should use this syntax:
  [`POST:/order-management/v1/images`](https://vippsas.github.io/vipps-developer-docs/api/order-management#tag/Image/operation/postImage)
- The Postman collection must be checked.
- The global Postman environment must contain all required parameters and sensible defaults.