### PR TITLE
Tom 43 fix documentation

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -506,6 +506,7 @@ components:
           description: 'Tax percentage for the order line. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 0.25 kr = 25 øre.'
           example: 25
           minimum: 0
+          maximum: 100
         unitInfo:
           $ref: '#/components/schemas/UnitInfo'
         discount:
@@ -535,6 +536,7 @@ components:
         - totalAmountExcludingTax
         - totalTaxAmount
         - taxPercentage
+        - isReturn
     BottomLine:
       title: BottomLine
       type: object

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -503,7 +503,7 @@ components:
           nullable: true
         taxPercentage:
           type: integer
-          description: 'Tax percentage for the order line. between 0-100'
+          description: 'Tax percentage for the order line. Between 0-100'
           example: 25
           minimum: 0
           maximum: 100

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -503,7 +503,7 @@ components:
           nullable: true
         taxPercentage:
           type: integer
-          description: 'Tax percentage for the order line. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 0.25 kr = 25 øre.'
+          description: 'Tax percentage for the order line. between 0-100'
           example: 25
           minimum: 0
           maximum: 100

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -479,37 +479,32 @@ components:
           type: string
           description: Name of the product in the order line.
           example: Vipps socks
-          nullable: true
         id:
           type: string
           description: The product ID
           example: '1234567890'
-          nullable: true
         totalAmount:
           type: integer
           description: 'Total amount of the order line, including tax and discount. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 10 kr = 1000 øre.'
           example: 1000
           format: int64
-          nullable: true
         totalAmountExcludingTax:
           type: integer
           description: 'Total amount of order line with discount excluding tax. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 8 kr = 800 øre.'
           example: 800
           format: int64
-          nullable: true
         totalTaxAmount:
           type: integer
           description: 'Total tax amount paid for the order line. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 2.5 kr = 250 øre.'
           example: 250
           format: int64
-          nullable: true
         taxPercentage:
           type: integer
           description: 'Tax percentage for the order line. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 0.25 kr = 25 øre.'
           example: 25
+          format: int32
           minimum: 0
           maximum: 100
-          nullable: true
         unitInfo:
           $ref: '#/components/schemas/UnitInfo'
         discount:
@@ -539,7 +534,6 @@ components:
         - totalAmountExcludingTax
         - totalTaxAmount
         - taxPercentage
-        - isReturn
     BottomLine:
       title: BottomLine
       type: object

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -505,6 +505,8 @@ components:
           type: integer
           description: 'Tax percentage for the order line. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 0.25 kr = 25 øre.'
           example: 25
+          minimum: 0
+          maximum: 100
           nullable: true
         unitInfo:
           $ref: '#/components/schemas/UnitInfo'

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -491,12 +491,6 @@ components:
           example: 1000
           format: int64
           nullable: true
-        totalAmount - copy:
-          type: integer
-          description: 'Total amount of the order line, including tax and discount. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 10 kr = 1000 øre.'
-          example: 1000
-          format: int64
-          nullable: true
         totalAmountExcludingTax:
           type: integer
           description: 'Total amount of order line with discount excluding tax. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 8 kr = 800 øre.'
@@ -539,7 +533,6 @@ components:
         - name
         - id
         - totalAmount
-        - totalAmount - copy
         - totalAmountExcludingTax
         - totalTaxAmount
         - taxPercentage

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -502,10 +502,13 @@ components:
           description: 'Total tax amount paid for the order line. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 2.5 kr = 250 øre.'
           example: 250
           format: int64
+          nullable: true
         taxPercentage:
           type: integer
           description: 'Tax percentage for the order line. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 0.25 kr = 25 øre.'
           example: 25
+          minimum: 0
+          maximum: 100
           nullable: true
         unitInfo:
           $ref: '#/components/schemas/UnitInfo'

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -488,23 +488,24 @@ components:
           description: 'Total amount of the order line, including tax and discount. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 10 kr = 1000 øre.'
           example: 1000
           format: int64
+          nullable: true
         totalAmountExcludingTax:
           type: integer
           description: 'Total amount of order line with discount excluding tax. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 8 kr = 800 øre.'
           example: 800
           format: int64
+          nullable: true
         totalTaxAmount:
           type: integer
           description: 'Total tax amount paid for the order line. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 2.5 kr = 250 øre.'
           example: 250
           format: int64
+          nullable: true
         taxPercentage:
           type: integer
           description: 'Tax percentage for the order line. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 0.25 kr = 25 øre.'
           example: 25
-          format: int32
-          minimum: 0
-          maximum: 100
+          nullable: true
         unitInfo:
           $ref: '#/components/schemas/UnitInfo'
         discount:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -479,34 +479,40 @@ components:
           type: string
           description: Name of the product in the order line.
           example: Vipps socks
+          nullable: true
         id:
           type: string
           description: The product ID
           example: '1234567890'
+          nullable: true
         totalAmount:
           type: integer
           description: 'Total amount of the order line, including tax and discount. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 10 kr = 1000 øre.'
           example: 1000
           format: int64
-          minimum: 0
+          nullable: true
+        totalAmount - copy:
+          type: integer
+          description: 'Total amount of the order line, including tax and discount. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 10 kr = 1000 øre.'
+          example: 1000
+          format: int64
+          nullable: true
         totalAmountExcludingTax:
           type: integer
           description: 'Total amount of order line with discount excluding tax. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 8 kr = 800 øre.'
           example: 800
           format: int64
-          minimum: 0
+          nullable: true
         totalTaxAmount:
           type: integer
           description: 'Total tax amount paid for the order line. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 2.5 kr = 250 øre.'
           example: 250
           format: int64
-          minimum: 0
         taxPercentage:
           type: integer
           description: 'Tax percentage for the order line. Amounts are specified in minor units. For Norwegian kroner (NOK) that means 1 kr = 100 øre. Example: 0.25 kr = 25 øre.'
           example: 25
-          minimum: 0
-          maximum: 100
+          nullable: true
         unitInfo:
           $ref: '#/components/schemas/UnitInfo'
         discount:
@@ -533,6 +539,7 @@ components:
         - name
         - id
         - totalAmount
+        - totalAmount - copy
         - totalAmountExcludingTax
         - totalTaxAmount
         - taxPercentage


### PR DESCRIPTION
This pr reverts some of the changes i've made earlier. 

By making ints & longs non-nullable we are breaking our validation in the backend due to this: https://learn.microsoft.com/en-us/aspnet/core/mvc/models/validation?view=aspnetcore-7.0#required-attribute:~:text=A%20non%2Dnullable%20field%20is%20always%20valid%2C%20and%20the%20%5BRequired%5D%20attribute%27s%20error%20message%20is%20never%20displayed.

