### PR TITLE
make category nullable

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -658,6 +658,7 @@ components:
         - DELIVERY
         - TICKET
         - BOOKING
+      nullable: true
     CurrencyEnum:
       type: string
       title: CurrencyEnum


### PR DESCRIPTION
Somehow if the field is not nullable, it is possible to leave it out of the request body when sending order request body